### PR TITLE
Fix: Ensure script operates in the correct directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ Prerequisites:
 
     **Warning:** The order of releases on the 3Dmigoto page is not completely chronological due to the way the file names are sorted, ensure that you are downloading the latest version by file name, not order in the list.
 
+3. [Steamless](https://github.com/atom0s/Steamless) 
 Installation: 
 
 1. Download a zip file of 3Dmigoto and save it to \<Steam Installation Location\>\SteamApps\common\ACE COMBAT 7.
 2. Clone this repository to, or download a zip and unpack it in, \<Steam Installation Location\>\SteamApps\common\ACE COMBAT 7.
-3. Double magic.py click to run.
+3. Place Steamless wherever you want
+4. Open Steamless.exe select Ace7Game.exe and click unpack file
+5. Backup old Ace7Game.exe and rename the unpacked exe to Ace7Game.exe
+6. Double magic.py click to run.
 
 Uninstallation:
 

--- a/magic.py
+++ b/magic.py
@@ -1,6 +1,10 @@
 import sys, os, shutil, binascii, zipfile, ctypes, math, glob, time
 from datetime import datetime
 
+# Sets it to the correct directory, it wants to do system32 for me every time - Hydraxon
+script_dir = os.path.dirname(os.path.realpath(__file__))
+os.chdir(script_dir)
+
 # Must be in game root folder.
 if not os.path.isfile('Ace7Game.exe'):
     wait = input('ERROR: Ace7Game.exe not found in this folder. Press any key to close...')


### PR DESCRIPTION
This update addresses an issue where the script was being executed in the System32 directory instead of the game root folder, despite being placed in the correct directory. This caused the script to fail to locate Ace7Game.exe.

To resolve this, I added a few lines at the beginning of the script to set the working directory explicitly to the directory where the script is located. This ensures the script operates in the intended directory and can correctly locate Ace7Game.exe.

Change:

- Added code to set the working directory to the script's directory at the beginning of the script.

These changes ensure that the script functions as expected when placed in the game root folder. (Yeah, this description was written by ChatGPT because I'm bad at describing things)